### PR TITLE
Splitter Interface for sklearn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "glassplitter"
-version = "0.1.2"
+version = "0.1.3"
 description = "A sentence splitter and tokenizer."
 authors = [{ name = "Luis Glaser", email = "Luis.Glaser@em.uni-frankfurt.de" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,8 @@ classifiers = ["Private :: Do not Upload"]
 requires-python = ">=3.8"
 dependencies = ["transformers", "pysbd"]
 
-
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "ruff"]
+dev = ["pytest>=7.0", "ruff>=0.2"]
 
 [build-system]
 requires = ["setuptools>=61.0"]
@@ -19,9 +18,22 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 
-
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["B", "E", "F", "I", "T20"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["glassplitter"]
+section-order = [
+    "future",
+    "typing",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder",
+]
+
+[tool.ruff.lint.isort.sections]
+"typing" = ["typing"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "glassplitter"
-version = "0.1.3"
+version = "0.1.4"
 description = "A sentence splitter and tokenizer."
 authors = [{ name = "Luis Glaser", email = "Luis.Glaser@em.uni-frankfurt.de" }]
 readme = "README.md"

--- a/src/glassplitter/tokenizer.py
+++ b/src/glassplitter/tokenizer.py
@@ -55,7 +55,8 @@ class Tokenizer:
                     span_id = next_index(span_id, spans)
                     continue
 
-                result.append((token, span_id))
+                if not trim or len(token):
+                    result.append((token, span_id))
 
                 if len(token) > 1:
                     words += 1

--- a/src/glassplitter/tokenizer.py
+++ b/src/glassplitter/tokenizer.py
@@ -1,5 +1,6 @@
-import logging
 from typing import Dict, Iterable, List, Tuple
+
+import logging
 
 import pysbd
 from transformers import BertTokenizerFast

--- a/src/glassplitter/tokenizer.py
+++ b/src/glassplitter/tokenizer.py
@@ -71,3 +71,21 @@ class Tokenizer:
         logger.debug(f"Split {len(sents)}. {hits}/{words} hits. ({hits/words:.0%})")
 
         return results
+
+    def split_flat(self, sentences: Iterable[str], trim=True):
+        if trim:
+            sentences = [s for s in sentences if len(s.strip())]
+
+        text = " ".join(sentences)
+        sents = self._segment(text)
+
+        result = []
+        for sent in sents:
+            encodings = self._tok(sent, return_offsets_mapping=True)
+            for i, _ in enumerate(encodings["input_ids"]):
+                begin, end = encodings["offset_mapping"][i]
+                token = sent[begin:end]
+                if len(token):
+                    result.append(token)
+
+        return result

--- a/test/test_splitting.py
+++ b/test/test_splitting.py
@@ -77,3 +77,45 @@ def test_trim_removes_surrounding_empty_tokens(tokenizer: Tokenizer):
             ("!", 1),
         ]
     ]
+
+
+def test_split_flat_creates_correct_splitting(tokenizer: Tokenizer):
+    example = [
+        "I am a sentence with trailing space. ",
+        "Different Box",
+        " from the rest of the sentence.Hello there.",
+        "StudNr something wrt TUD & KHG",
+    ]
+    actual = tokenizer.split_flat(example, trim=True)
+    assert actual == [
+        "I",
+        "am",
+        "a",
+        "sentence",
+        "with",
+        "trailing",
+        "space",
+        ".",
+        "Different",
+        "Box",
+        "from",
+        "the",
+        "rest",
+        "of",
+        "the",
+        "sentence",
+        ".",
+        "Hello",
+        "there",
+        ".",
+        "Stud",
+        "Nr",
+        "something",
+        "wr",
+        "t",
+        "TU",
+        "D",
+        "&",
+        "K",
+        "HG",
+    ]

--- a/test/test_splitting.py
+++ b/test/test_splitting.py
@@ -1,4 +1,5 @@
 import pytest
+
 from glassplitter.tokenizer import Tokenizer
 
 

--- a/test/test_splitting.py
+++ b/test/test_splitting.py
@@ -1,0 +1,78 @@
+import pytest
+from glassplitter.tokenizer import Tokenizer
+
+
+@pytest.fixture(
+    params=[
+        {"doc_type": "pdf"},
+        {"doc_type": None},
+    ],
+    ids=["pdf", "unknown"],
+)
+def tokenizer(request):
+    return Tokenizer(**request.param)
+
+
+def test_empty_first_word(tokenizer: Tokenizer):
+    spans = ["", "This is a fun sentence!"]
+    result = tokenizer._split(spans)
+    assert len(result) == 1
+
+
+def assert_tokens_in_spans(actual, example):
+    for a in actual:
+        for text, span in a:
+            assert text in example[span]
+
+
+def test_splitting(tokenizer: Tokenizer):
+    example = [
+        "I am a sentence with trailing space. ",
+        "Different Box",
+        " from the rest of the sentence.Hello there.",
+        "StudNr something wrt TUD & KHG",
+    ]
+    example_input = [(text, {"some_data": "schwund is immer"}) for text in example]
+    actual = tokenizer.split(example_input, trim=True)
+    assert len(actual) == 4, "There should be 4 sentences."
+    assert_tokens_in_spans(actual, example)
+
+
+def test_filtered_spans_arent_referenced(tokenizer: Tokenizer):
+    spans = ["", "This is the second sentence!"]
+    result = tokenizer._split(spans)
+    assert all(0 != span_id for _, span_id in result[0])
+
+
+def test_ids_are_assigned_correctly(tokenizer: Tokenizer):
+    spans = [("I am a ", {"line": 1}), ("split sentence!", {"line": 2})]
+
+    split = tokenizer.split(spans, trim=False)
+    assert split == [
+        [
+            ("", 0),
+            ("I", 0),
+            ("am", 0),
+            ("a", 0),
+            ("split", 1),
+            ("sentence", 1),
+            ("!", 1),
+            ("", 1),
+        ]
+    ]
+
+
+def test_trim_removes_surrounding_empty_tokens(tokenizer: Tokenizer):
+    spans = [("I am a ", {"line": 1}), ("split sentence!", {"line": 2})]
+
+    split = tokenizer.split(spans, trim=True)
+    assert split == [
+        [
+            ("I", 0),
+            ("am", 0),
+            ("a", 0),
+            ("split", 1),
+            ("sentence", 1),
+            ("!", 1),
+        ]
+    ]


### PR DESCRIPTION
Tokenizer now offers a method that returns a flat list of tokens. Note the test already hints that some abbreviations are split weirdly (K-HG, TU-D, ..) 
We dont have to fix that right now, though.
Please have a look whether the method does what you need.
Closes #4 

---

Also both methods will remove empty tokens if `trim=True`
Closes #3
